### PR TITLE
Use a RELEASE_TOKEN PAT for auto shipit's push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,11 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Use a PAT so `auto shipit` can push the version bump + tag back to
+          # `main` — the default GITHUB_TOKEN is blocked by the `main: require CI`
+          # ruleset (github-actions[bot] is not in the bypass list).
+          token: ${{ secrets.RELEASE_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: '24.x'
@@ -68,5 +73,5 @@ jobs:
       - run: git fetch --unshallow --tags
       - run: npm x -y auto shipit
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
           # Use a PAT so `auto shipit` can push the version bump + tag back to
           # `main` — the default GITHUB_TOKEN is blocked by the `main: require CI`
           # ruleset (github-actions[bot] is not in the bypass list).
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: '24.x'
@@ -73,5 +73,5 @@ jobs:
       - run: git fetch --unshallow --tags
       - run: npm x -y auto shipit
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'


### PR DESCRIPTION
## Intent

Make the publish job's push to `main` actually work under the `main: require CI` ruleset by signing the push with a personal access token that bypasses required status checks.

## Why

The new ruleset on `main` requires CI status checks to pass before any update — including direct pushes. `auto shipit` does `npm publish` first, then pushes a bump commit + tag back to `main`. That push is rejected with `GH013: Repository rule violations` because `github-actions[bot]` (the identity used by GITHUB_TOKEN) isn't recognised as the Write or Admin role for the ruleset's bypass list:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - 2 of 2 required status checks are expected.
 ! [remote rejected] main -> main (push declined due to repository rule violations)
 ! [remote rejected] v0.2.7 -> v0.2.7 (atomic transaction failed)
```

Result: npm gets the new version, but git ends up out of sync (no tag, `package.json` still on the old version).

A fine-grained PAT owned by an admin user *does* bypass cleanly. (Verified: I pushed the recovery commit + tag from my admin account with `remote: Bypassed rule violations for refs/heads/main`.)

## What changed

`actions/checkout` in the publish job now consumes `${{ secrets.RELEASE_TOKEN }}`, and the `auto shipit` step's `GH_TOKEN` env switches to the same secret. Everything else is untouched.

## Required setup before merging

1. Create a fine-grained PAT at https://github.com/settings/personal-access-tokens/new
   - **Resource owner**: jameslnewell
   - **Repository access**: Only select repositories → tick `buildkite-pipelines`, `github-changes`, `git-diff` (one token works for all three)
   - **Permissions**: `Contents: Read and write`, `Metadata: Read-only` (default)
2. Add the token as a repository secret named `RELEASE_TOKEN` on this repo (and the other two).

(Or use a classic PAT with `repo` scope — slightly broader but also works.)